### PR TITLE
Update loadSchemas to index using correct property

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ function loadSchemas(schemaDirectory) {
   filepaths.forEach(filepath => {
     if (filepath.endsWith('.json')) {
       const schema = loadSchema(filepath);
-      schemas[schema.id || schema.title] = schema;
+      schemas[schema['$id'] || schema.title] = schema;
     }
   });
   return schemas;


### PR DESCRIPTION
Since draft 06 of the JSON Schema specs the property $id has been used to identify a schema.
This is how it should be indexed from a $ref in another schema